### PR TITLE
Fix star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,11 +502,11 @@ This implementation builds on code and models from [aigc-apps/VideoX-Fun](https:
 ---
 ## Star History
 
-<a href="https://www.star-history.com/?repos=netflix%2Fvoid-model&type=date&legend=bottom-right">
+<a href="https://star-history.dera.page/#netflix/void-model&type=date&legend=bottom-right">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=netflix/void-model&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=netflix/void-model&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=netflix/void-model&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=netflix/void-model&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=netflix/void-model&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=netflix/void-model&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points the chart at a working provider so it renders again.